### PR TITLE
Fix react-autocomplete renderItem prop type

### DIFF
--- a/types/react-autocomplete/index.d.ts
+++ b/types/react-autocomplete/index.d.ts
@@ -65,7 +65,7 @@ declare namespace Autocomplete {
          * an optional set of styles that can be applied to improve the look/feel
          * of the items in the dropdown menu.
          */
-        renderItem: (item: any, isHighlighted: boolean) => ReactNode;
+        renderItem: (item: any, isHighlighted: boolean, styles?: CSSProperties) => ReactNode;
         /**
          * Arguments: `items: Array<Any>, value: String, styles: Object`
          *

--- a/types/react-autocomplete/index.d.ts
+++ b/types/react-autocomplete/index.d.ts
@@ -65,7 +65,7 @@ declare namespace Autocomplete {
          * an optional set of styles that can be applied to improve the look/feel
          * of the items in the dropdown menu.
          */
-        renderItem: (item: any) => ReactNode;
+        renderItem: (item: any, isHighlighted: boolean) => ReactNode;
         /**
          * Arguments: `items: Array<Any>, value: String, styles: Object`
          *


### PR DESCRIPTION
I fixed the missing second argument in the renderItem prop type of react-autocomplete. See: https://github.com/reactjs/react-autocomplete/blob/master/README.md#renderitem-function

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactjs/react-autocomplete/blob/master/README.md#renderitem-function>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.